### PR TITLE
Update 03-InferringRates.Rmd

### DIFF
--- a/03-InferringRates.Rmd
+++ b/03-InferringRates.Rmd
@@ -290,7 +290,7 @@ draws_df <- draws_df %>% mutate(
 ggplot(draws_df) +
   geom_density(aes(theta), fill = "blue", alpha = 0.3) +
   geom_density(aes(theta_prior), fill = "red", alpha = 0.3) +
-  geom_vline(xintercept = 0.8, linetype = "dashed", color = "black", size = 1.5) +
+  geom_vline(xintercept = 1.38, linetype = "dashed", color = "black", size = 1.5) +
   xlab("Rate") +
   ylab("Posterior Density") +
   theme_classic()


### PR DESCRIPTION
Regarding the plot of the prior/posterior estimates of the first log-odds model. Not sure about this, but shouldn't the dashed line, which represents the true _rate_ of _0.8_ be also converted to log-odds (0.8 -> ~1.38)?